### PR TITLE
Fixed null error

### DIFF
--- a/export_spotify_playlist_to_json.js
+++ b/export_spotify_playlist_to_json.js
@@ -1,4 +1,4 @@
-document.querySelector("div.main-view-container div.os-viewport.os-viewport-native-scrollbars-invisible").scrollTo(0,0);
+document.querySelector("main").scrollTo(0,0);
 result = [];
 console.log("Starting in 3 sec");
 document.body.style.pointerEvents = "none !important";


### PR DESCRIPTION
Fixed scroll to actually work and not cause this error `Cannot read properties of null (reading 'scrollTo')`

![image](https://github.com/Doskii/Spotify-playlist-to-JSON/assets/95449321/6eed1161-02fe-47ba-a15d-f2781d55940e)
